### PR TITLE
remove closing PHP tag

### DIFF
--- a/Lib/RelativeTime/Autoload.php
+++ b/Lib/RelativeTime/Autoload.php
@@ -19,5 +19,3 @@ if (function_exists('spl_autoload_register'))
         }
     });
 }
-
-?>

--- a/Lib/RelativeTime/Languages/English.php
+++ b/Lib/RelativeTime/Languages/English.php
@@ -47,5 +47,3 @@ class English extends LanguageAdapter
         ),
     );
 }
-
-?>

--- a/Lib/RelativeTime/Languages/French.php
+++ b/Lib/RelativeTime/Languages/French.php
@@ -47,5 +47,3 @@ class French extends LanguageAdapter
         ),
     );
 }
-
-?>

--- a/Lib/RelativeTime/Languages/German.php
+++ b/Lib/RelativeTime/Languages/German.php
@@ -47,5 +47,3 @@ class German extends LanguageAdapter
         ),
     );
 }
-
-?>

--- a/Lib/RelativeTime/Languages/LanguageAdapter.php
+++ b/Lib/RelativeTime/Languages/LanguageAdapter.php
@@ -85,5 +85,3 @@ abstract class LanguageAdapter implements ArrayAccess
         return array_keys($this->strings);
     }
 }
-
-?>

--- a/Lib/RelativeTime/Languages/PortugueseBR.php
+++ b/Lib/RelativeTime/Languages/PortugueseBR.php
@@ -47,5 +47,3 @@ class PortugueseBR extends LanguageAdapter
         ),
     );
 }
-
-?>

--- a/Lib/RelativeTime/Languages/Spanish.php
+++ b/Lib/RelativeTime/Languages/Spanish.php
@@ -47,5 +47,3 @@ class Spanish extends LanguageAdapter
         ),
     );
 }
-
-?>

--- a/Lib/RelativeTime/RelativeTime.php
+++ b/Lib/RelativeTime/RelativeTime.php
@@ -158,4 +158,3 @@ class RelativeTime
         return $units;
     }
 }
-?>

--- a/Lib/RelativeTime/Translation.php
+++ b/Lib/RelativeTime/Translation.php
@@ -109,4 +109,3 @@ class Translation
         return new English();
     }
 }
-?>

--- a/Tests/Autoload.php
+++ b/Tests/Autoload.php
@@ -1,4 +1,3 @@
 <?php
 require __DIR__ . '/../Lib/RelativeTime/Autoload.php';
 date_default_timezone_set('UTC');
-?>

--- a/Tests/TestLanguageAdapter.php
+++ b/Tests/TestLanguageAdapter.php
@@ -64,5 +64,3 @@ class TestLanguageAdapter extends PHPUnit_Framework_TestCase
         $english['unknown_key'];
     }
 }
-
-?>

--- a/Tests/TestRelativeTime.php
+++ b/Tests/TestRelativeTime.php
@@ -175,5 +175,3 @@ class TestRelativeTime extends PHPUnit_Framework_TestCase
         $this->assertEquals($result, '2 years, 6 months, 30 days, 15 hours, 12 minutes, 3 seconds ago');
     }
 }
-
-?>

--- a/Tests/TestTranslation.php
+++ b/Tests/TestTranslation.php
@@ -107,5 +107,3 @@ class TestTranslation extends PHPUnit_Framework_TestCase
         $this->assertEquals($result, '1 Stunde, 5 Tage');
     }
 }
-
-?>


### PR DESCRIPTION
Closing PHP tags at end of files are not required and are officially discouraged by PHP, as they introduce undesirable whitespace being sent as output.